### PR TITLE
ai ← updates

### DIFF
--- a/src/lib/editable-store.ts
+++ b/src/lib/editable-store.ts
@@ -84,7 +84,7 @@ export class EditableStore {
 		identifier: { key: string } | { collection: string; item: string | number; fields?: string[] } | null,
 	) {
 		if (this.highlightedKey !== null) {
-			EditableStore.getItemByKey(this.highlightedKey)?.overlayElement.toggleAiContext(false);
+			EditableStore.getItemByKey(this.highlightedKey)?.overlayElement.toggleHighlightActive(false);
 		}
 
 		if (identifier === null) {
@@ -102,13 +102,13 @@ export class EditableStore {
 
 		if (element) {
 			this.highlightedKey = element.key;
-			element.overlayElement.toggleAiContext(true);
+			element.overlayElement.toggleHighlightActive(true);
 		} else {
 			this.highlightedKey = null;
 		}
 	}
 
 	static setElementInAiContext(key: string, inContext: boolean) {
-		EditableStore.getItemByKey(key)?.overlayElement.toggleAiContext(inContext);
+		EditableStore.getItemByKey(key)?.overlayElement.toggleHighlightActive(inContext);
 	}
 }

--- a/src/lib/overlay-element.ts
+++ b/src/lib/overlay-element.ts
@@ -102,8 +102,8 @@ export class OverlayElement {
 		this.element.classList.toggle(OverlayManager.RECT_HIGHLIGHT_CLASS_NAME, show);
 	}
 
-	toggleAiContext(show: boolean) {
-		this.element.classList.toggle(OverlayManager.RECT_AI_CONTEXT_CLASS_NAME, show);
+	toggleHighlightActive(show: boolean) {
+		this.element.classList.toggle(OverlayManager.RECT_HIGHLIGHT_ACTIVE_CLASS_NAME, show);
 	}
 
 	disable() {

--- a/src/lib/overlay-manager.ts
+++ b/src/lib/overlay-manager.ts
@@ -9,9 +9,9 @@ export class OverlayManager {
 	private static readonly CSS_VAR_BUTTON_WIDTH = '--directus-visual-editing--edit-btn--width';
 	private static readonly CSS_VAR_BUTTON_HEIGHT = '--directus-visual-editing--edit-btn--height';
 	private static readonly CSS_VAR_BUTTON_RADIUS = '--directus-visual-editing--edit-btn--radius';
-	private static readonly CSS_VAR_BUTTON_BG_COLOR = '--directus-visual-editing--edit-btn--bg-color';
-	private static readonly CSS_VAR_BUTTON_ICON_BG_IMAGE = '--directus-visual-editing--edit-btn--icon-bg-image';
-	private static readonly CSS_VAR_BUTTON_ICON_BG_SIZE = '--directus-visual-editing--edit-btn--icon-bg-size';
+	private static readonly CSS_VAR_EDIT_BUTTON_BG_COLOR = '--directus-visual-editing--edit-btn--bg-color';
+	private static readonly CSS_VAR_EDIT_BUTTON_ICON_BG_IMAGE = '--directus-visual-editing--edit-btn--icon-bg-image';
+	private static readonly CSS_VAR_EDIT_BUTTON_ICON_BG_SIZE = '--directus-visual-editing--edit-btn--icon-bg-size';
 	private static readonly CSS_VAR_AI_BUTTON_BG_COLOR = '--directus-visual-editing--ai-btn--bg-color';
 	private static readonly CSS_VAR_AI_BUTTON_ICON_BG_IMAGE = '--directus-visual-editing--ai-btn--icon-bg-image';
 	private static readonly CSS_VAR_AI_CONTEXT_BORDER_COLOR = '--directus-visual-editing--ai-context--border-color';
@@ -109,7 +109,7 @@ export class OverlayManager {
 					width: var(${OverlayManager.CSS_VAR_BUTTON_WIDTH}, ${buttonWidth}px);
 					height: var(${OverlayManager.CSS_VAR_BUTTON_HEIGHT}, ${buttonWidth}px);
 					border-radius: var(${OverlayManager.CSS_VAR_BUTTON_RADIUS}, 50%);
-					background-size: var(${OverlayManager.CSS_VAR_BUTTON_ICON_BG_SIZE}, 66.6%);
+					background-size: var(${OverlayManager.CSS_VAR_EDIT_BUTTON_ICON_BG_SIZE}, 66.6%);
 					background-position: center;
 					background-repeat: no-repeat;
 					opacity: 0;
@@ -119,12 +119,12 @@ export class OverlayManager {
 				}
 				.${OverlayManager.RECT_BUTTON_CLASS_NAME}.${OverlayManager.RECT_EDIT_BUTTON_CLASS_NAME} {
 					left: calc(-1 * ${borderSpacing} + ${borderWidth} / 2);
-					background-color: var(${OverlayManager.CSS_VAR_BUTTON_BG_COLOR}, #6644ff);
-					background-image: var(${OverlayManager.CSS_VAR_BUTTON_ICON_BG_IMAGE}, ${OverlayManager.ICON_EDIT});
+					background-color: var(${OverlayManager.CSS_VAR_EDIT_BUTTON_BG_COLOR}, #6644ff);
+					background-image: var(${OverlayManager.CSS_VAR_EDIT_BUTTON_ICON_BG_IMAGE}, ${OverlayManager.ICON_EDIT});
 				}
 				.${OverlayManager.RECT_BUTTON_CLASS_NAME}.${OverlayManager.RECT_AI_BUTTON_CLASS_NAME} {
 					left: calc(-1 * ${borderSpacing} + ${borderWidth} / 2 + var(${OverlayManager.CSS_VAR_BUTTON_WIDTH}, ${buttonWidth}px) + 8px);
-					background-color: var(${OverlayManager.CSS_VAR_AI_BUTTON_BG_COLOR}, var(${OverlayManager.CSS_VAR_BUTTON_BG_COLOR}, #6644ff));
+					background-color: var(${OverlayManager.CSS_VAR_AI_BUTTON_BG_COLOR}, var(${OverlayManager.CSS_VAR_EDIT_BUTTON_BG_COLOR}, #6644ff));
 					background-image: var(${OverlayManager.CSS_VAR_AI_BUTTON_ICON_BG_IMAGE}, ${OverlayManager.ICON_AI});
 				}
 				.${OverlayManager.RECT_CLASS_NAME}.${OverlayManager.RECT_HOVER_CLASS_NAME}:not(.${OverlayManager.RECT_PARENT_HOVER_CLASS_NAME}) .${OverlayManager.RECT_BUTTON_CLASS_NAME},
@@ -133,11 +133,11 @@ export class OverlayManager {
 				}
 				.${OverlayManager.RECT_CLASS_NAME}.${OverlayManager.RECT_HOVER_CLASS_NAME}:not(.${OverlayManager.RECT_PARENT_HOVER_CLASS_NAME}) .${OverlayManager.RECT_EDIT_BUTTON_CLASS_NAME},
 				.${OverlayManager.RECT_HIGHLIGHT_CLASS_NAME}:hover .${OverlayManager.RECT_EDIT_BUTTON_CLASS_NAME} {
-					background-color: color-mix(in srgb, var(${OverlayManager.CSS_VAR_BUTTON_BG_COLOR}, #6644ff) 85%, white);
+					background-color: color-mix(in srgb, var(${OverlayManager.CSS_VAR_EDIT_BUTTON_BG_COLOR}, #6644ff) 85%, white);
 				}
 				.${OverlayManager.RECT_CLASS_NAME}.${OverlayManager.RECT_HOVER_CLASS_NAME}:not(.${OverlayManager.RECT_PARENT_HOVER_CLASS_NAME}) .${OverlayManager.RECT_AI_BUTTON_CLASS_NAME},
 				.${OverlayManager.RECT_HIGHLIGHT_CLASS_NAME}:hover .${OverlayManager.RECT_AI_BUTTON_CLASS_NAME} {
-					background-color: color-mix(in srgb, var(${OverlayManager.CSS_VAR_AI_BUTTON_BG_COLOR}, var(${OverlayManager.CSS_VAR_BUTTON_BG_COLOR}, #6644ff)) 85%, white);
+					background-color: color-mix(in srgb, var(${OverlayManager.CSS_VAR_AI_BUTTON_BG_COLOR}, var(${OverlayManager.CSS_VAR_EDIT_BUTTON_BG_COLOR}, #6644ff)) 85%, white);
 				}
 				.${OverlayManager.RECT_BUTTON_CLASS_NAME}:hover ~ .${OverlayManager.RECT_INNER_CLASS_NAME},
 				.${OverlayManager.RECT_HIGHLIGHT_CLASS_NAME}:hover .${OverlayManager.RECT_INNER_CLASS_NAME} {
@@ -147,10 +147,10 @@ export class OverlayManager {
 					opacity: 1;
 				}
 				.${OverlayManager.RECT_CLASS_NAME}:has(.${OverlayManager.RECT_EDIT_BUTTON_CLASS_NAME}:hover) .${OverlayManager.RECT_AI_BUTTON_CLASS_NAME} {
-					background-color: color-mix(in srgb, var(${OverlayManager.CSS_VAR_AI_BUTTON_BG_COLOR}, var(${OverlayManager.CSS_VAR_BUTTON_BG_COLOR}, #6644ff)) 85%, white);
+					background-color: color-mix(in srgb, var(${OverlayManager.CSS_VAR_AI_BUTTON_BG_COLOR}, var(${OverlayManager.CSS_VAR_EDIT_BUTTON_BG_COLOR}, #6644ff)) 85%, white);
 				}
 				.${OverlayManager.RECT_CLASS_NAME}:has(.${OverlayManager.RECT_AI_BUTTON_CLASS_NAME}:hover) .${OverlayManager.RECT_EDIT_BUTTON_CLASS_NAME} {
-					background-color: color-mix(in srgb, var(${OverlayManager.CSS_VAR_BUTTON_BG_COLOR}, #6644ff) 85%, white);
+					background-color: color-mix(in srgb, var(${OverlayManager.CSS_VAR_EDIT_BUTTON_BG_COLOR}, #6644ff) 85%, white);
 				}
 				.${OverlayManager.RECT_AI_CONTEXT_CLASS_NAME} .${OverlayManager.RECT_INNER_CLASS_NAME} {
 					border-color: var(${OverlayManager.CSS_VAR_AI_CONTEXT_BORDER_COLOR}, var(${OverlayManager.CSS_VAR_BORDER_COLOR}, #6644ff));

--- a/src/lib/overlay-manager.ts
+++ b/src/lib/overlay-manager.ts
@@ -14,7 +14,6 @@ export class OverlayManager {
 	private static readonly CSS_VAR_EDIT_BUTTON_ICON_BG_SIZE = '--directus-visual-editing--edit-btn--icon-bg-size';
 	private static readonly CSS_VAR_AI_BUTTON_BG_COLOR = '--directus-visual-editing--ai-btn--bg-color';
 	private static readonly CSS_VAR_AI_BUTTON_ICON_BG_IMAGE = '--directus-visual-editing--ai-btn--icon-bg-image';
-	private static readonly CSS_VAR_AI_CONTEXT_BORDER_COLOR = '--directus-visual-editing--ai-context--border-color';
 
 	// For icons use https://fonts.google.com/icons?icon.set=Material+Icons&icon.color=%23ffffff
 	private static readonly ICON_EDIT = `url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="%23ffffff"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M14.06 9.02l.92.92L5.92 19H5v-.92l9.06-9.06M17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75z"/></svg>')`;
@@ -26,13 +25,13 @@ export class OverlayManager {
 	static readonly CONTAINER_RECT_CLASS_NAME = 'directus-visual-editing-overlay';
 	static readonly RECT_CLASS_NAME = 'directus-visual-editing-rect';
 	static readonly RECT_HIGHLIGHT_CLASS_NAME = 'directus-visual-editing-rect-highlight';
+	static readonly RECT_HIGHLIGHT_ACTIVE_CLASS_NAME = 'directus-visual-editing-rect-highlight-active';
 	static readonly RECT_PARENT_HOVER_CLASS_NAME = 'directus-visual-editing-rect-parent-hover';
 	static readonly RECT_HOVER_CLASS_NAME = 'directus-visual-editing-rect-hover';
 	static readonly RECT_INNER_CLASS_NAME = 'directus-visual-editing-rect-inner';
 	static readonly RECT_BUTTON_CLASS_NAME = 'directus-visual-editing-button';
 	static readonly RECT_EDIT_BUTTON_CLASS_NAME = 'directus-visual-editing-edit-button';
 	static readonly RECT_AI_BUTTON_CLASS_NAME = 'directus-visual-editing-ai-button';
-	static readonly RECT_AI_CONTEXT_CLASS_NAME = 'directus-visual-editing-rect-ai-context';
 
 	static getGlobalOverlay(): HTMLElement {
 		const existingOverlay = document.getElementById(OverlayManager.OVERLAY_ID);
@@ -152,11 +151,7 @@ export class OverlayManager {
 				.${OverlayManager.RECT_CLASS_NAME}:has(.${OverlayManager.RECT_AI_BUTTON_CLASS_NAME}:hover) .${OverlayManager.RECT_EDIT_BUTTON_CLASS_NAME} {
 					background-color: color-mix(in srgb, var(${OverlayManager.CSS_VAR_EDIT_BUTTON_BG_COLOR}, #6644ff) 85%, white);
 				}
-				.${OverlayManager.RECT_AI_CONTEXT_CLASS_NAME} .${OverlayManager.RECT_INNER_CLASS_NAME} {
-					border-color: var(${OverlayManager.CSS_VAR_AI_CONTEXT_BORDER_COLOR}, var(${OverlayManager.CSS_VAR_BORDER_COLOR}, #6644ff));
-					opacity: 1;
-				}
-				.${OverlayManager.RECT_AI_CONTEXT_CLASS_NAME} .${OverlayManager.RECT_AI_BUTTON_CLASS_NAME} {
+				.${OverlayManager.RECT_HIGHLIGHT_ACTIVE_CLASS_NAME} .${OverlayManager.RECT_INNER_CLASS_NAME} {
 					opacity: 1;
 				}
 			`),

--- a/src/lib/overlay-manager.ts
+++ b/src/lib/overlay-manager.ts
@@ -14,6 +14,7 @@ export class OverlayManager {
 	private static readonly CSS_VAR_EDIT_BUTTON_ICON_BG_SIZE = '--directus-visual-editing--edit-btn--icon-bg-size';
 	private static readonly CSS_VAR_AI_BUTTON_BG_COLOR = '--directus-visual-editing--ai-btn--bg-color';
 	private static readonly CSS_VAR_AI_BUTTON_ICON_BG_IMAGE = '--directus-visual-editing--ai-btn--icon-bg-image';
+	private static readonly CSS_VAR_AI_BUTTON_ICON_BG_SIZE = '--directus-visual-editing--ai-btn--icon-bg-size';
 
 	// For icons use https://fonts.google.com/icons?icon.set=Material+Icons&icon.color=%23ffffff
 	private static readonly ICON_EDIT = `url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="%23ffffff"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M14.06 9.02l.92.92L5.92 19H5v-.92l9.06-9.06M17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75z"/></svg>')`;
@@ -112,7 +113,6 @@ export class OverlayManager {
 					width: var(${OverlayManager.CSS_VAR_BUTTON_WIDTH}, ${buttonWidth}px);
 					height: var(${OverlayManager.CSS_VAR_BUTTON_HEIGHT}, ${buttonWidth}px);
 					border-radius: var(${OverlayManager.CSS_VAR_BUTTON_RADIUS}, 50%);
-					background-size: var(${OverlayManager.CSS_VAR_EDIT_BUTTON_ICON_BG_SIZE}, 66.6%);
 					background-position: center;
 					background-repeat: no-repeat;
 					opacity: 0;
@@ -124,11 +124,13 @@ export class OverlayManager {
 					left: calc(-1 * ${borderSpacing} + ${borderWidth} / 2);
 					background-color: var(${OverlayManager.CSS_VAR_EDIT_BUTTON_BG_COLOR}, #6644ff);
 					background-image: var(${OverlayManager.CSS_VAR_EDIT_BUTTON_ICON_BG_IMAGE}, ${OverlayManager.ICON_EDIT});
+					background-size: var(${OverlayManager.CSS_VAR_EDIT_BUTTON_ICON_BG_SIZE}, 66.6%);
 				}
 				.${OverlayManager.RECT_BUTTON_CLASS_NAME}.${OverlayManager.RECT_AI_BUTTON_CLASS_NAME} {
 					left: calc(-1 * ${borderSpacing} + ${borderWidth} / 2 + var(${OverlayManager.CSS_VAR_BUTTON_WIDTH}, ${buttonWidth}px) + 8px);
 					background-color: var(${OverlayManager.CSS_VAR_AI_BUTTON_BG_COLOR}, var(${OverlayManager.CSS_VAR_EDIT_BUTTON_BG_COLOR}, #6644ff));
 					background-image: var(${OverlayManager.CSS_VAR_AI_BUTTON_ICON_BG_IMAGE}, ${OverlayManager.ICON_AI});
+					background-size: var(${OverlayManager.CSS_VAR_AI_BUTTON_ICON_BG_SIZE}, 66.6%);
 				}
 				.${OverlayManager.RECT_CLASS_NAME}.${OverlayManager.RECT_HOVER_CLASS_NAME}:not(.${OverlayManager.RECT_PARENT_HOVER_CLASS_NAME}) .${OverlayManager.RECT_BUTTON_CLASS_NAME},
 				.${OverlayManager.RECT_HIGHLIGHT_CLASS_NAME}:hover .${OverlayManager.RECT_BUTTON_CLASS_NAME} {

--- a/src/lib/overlay-manager.ts
+++ b/src/lib/overlay-manager.ts
@@ -97,6 +97,10 @@ export class OverlayManager {
 				.${OverlayManager.RECT_HIGHLIGHT_CLASS_NAME} .${OverlayManager.RECT_INNER_CLASS_NAME}  {
 					opacity: var(${OverlayManager.CSS_VAR_HIGHLIGHT_OPACITY}, 0.333);
 				}
+				.${OverlayManager.RECT_BUTTON_CLASS_NAME}:visited,
+				.${OverlayManager.RECT_BUTTON_CLASS_NAME}:active,
+				.${OverlayManager.RECT_BUTTON_CLASS_NAME}:hover,
+				.${OverlayManager.RECT_BUTTON_CLASS_NAME}:focus,
 				.${OverlayManager.RECT_BUTTON_CLASS_NAME} {
 					all: initial;
 					pointer-events: all;

--- a/src/lib/overlay-manager.ts
+++ b/src/lib/overlay-manager.ts
@@ -56,6 +56,9 @@ export class OverlayManager {
 		const buttonSize = 28;
 		const buttonWidth = `var(${OverlayManager.CSS_VAR_BUTTON_WIDTH}, ${buttonSize}px)`;
 		const buttonGap = 4;
+		const editButtonBgColor = `var(${OverlayManager.CSS_VAR_EDIT_BUTTON_BG_COLOR}, #6644ff)`;
+		const aiButtonBgColor = `var(${OverlayManager.CSS_VAR_AI_BUTTON_BG_COLOR}, ${editButtonBgColor})`;
+		const buttonBgColorMix = '#2e3C43 25%';
 		const borderSpacing = `var(${OverlayManager.CSS_VAR_BORDER_SPACING}, ${Math.round(buttonSize * 0.333)}px)`;
 		const borderWidth = `var(${OverlayManager.CSS_VAR_BORDER_WIDTH}, 2px)`;
 
@@ -120,48 +123,32 @@ export class OverlayManager {
 					background-repeat: no-repeat;
 					opacity: 0;
 				}
-				.${OverlayManager.RECT_BUTTON_CLASS_NAME}:hover {
-					opacity: 1;
-				}
 				.${OverlayManager.RECT_BUTTON_CLASS_NAME}.${OverlayManager.RECT_EDIT_BUTTON_CLASS_NAME} {
 					left: calc(-1 * ${borderSpacing} + ${borderWidth} / 2);
-					background-color: var(${OverlayManager.CSS_VAR_EDIT_BUTTON_BG_COLOR}, #6644ff);
+					background-color: ${editButtonBgColor};
 					background-image: var(${OverlayManager.CSS_VAR_EDIT_BUTTON_ICON_BG_IMAGE}, ${OverlayManager.ICON_EDIT});
 					background-size: var(${OverlayManager.CSS_VAR_EDIT_BUTTON_ICON_BG_SIZE}, 66.6%);
 				}
 				.${OverlayManager.RECT_BUTTON_CLASS_NAME}.${OverlayManager.RECT_AI_BUTTON_CLASS_NAME} {
 					left: calc(-1 * ${borderSpacing} + ${borderWidth} / 2 + ${buttonWidth} + var(${OverlayManager.CSS_VAR_ACTIONS_GAP}, ${buttonGap}px));
-					background-color: var(${OverlayManager.CSS_VAR_AI_BUTTON_BG_COLOR}, var(${OverlayManager.CSS_VAR_EDIT_BUTTON_BG_COLOR}, #6644ff));
+					background-color: ${aiButtonBgColor};
 					background-image: var(${OverlayManager.CSS_VAR_AI_BUTTON_ICON_BG_IMAGE}, ${OverlayManager.ICON_AI});
 					background-size: var(${OverlayManager.CSS_VAR_AI_BUTTON_ICON_BG_SIZE}, 66.6%);
 				}
 				.${OverlayManager.RECT_CLASS_NAME}.${OverlayManager.RECT_HOVER_CLASS_NAME}:not(.${OverlayManager.RECT_PARENT_HOVER_CLASS_NAME}) .${OverlayManager.RECT_BUTTON_CLASS_NAME},
-				.${OverlayManager.RECT_HIGHLIGHT_CLASS_NAME}:hover .${OverlayManager.RECT_BUTTON_CLASS_NAME} {
-					opacity: 1;
-				}
-				.${OverlayManager.RECT_CLASS_NAME}.${OverlayManager.RECT_HOVER_CLASS_NAME}:not(.${OverlayManager.RECT_PARENT_HOVER_CLASS_NAME}) .${OverlayManager.RECT_EDIT_BUTTON_CLASS_NAME},
-				.${OverlayManager.RECT_HIGHLIGHT_CLASS_NAME}:hover .${OverlayManager.RECT_EDIT_BUTTON_CLASS_NAME} {
-					background-color: color-mix(in srgb, var(${OverlayManager.CSS_VAR_EDIT_BUTTON_BG_COLOR}, #6644ff) 85%, white);
-				}
-				.${OverlayManager.RECT_CLASS_NAME}.${OverlayManager.RECT_HOVER_CLASS_NAME}:not(.${OverlayManager.RECT_PARENT_HOVER_CLASS_NAME}) .${OverlayManager.RECT_AI_BUTTON_CLASS_NAME},
-				.${OverlayManager.RECT_HIGHLIGHT_CLASS_NAME}:hover .${OverlayManager.RECT_AI_BUTTON_CLASS_NAME} {
-					background-color: color-mix(in srgb, var(${OverlayManager.CSS_VAR_AI_BUTTON_BG_COLOR}, var(${OverlayManager.CSS_VAR_EDIT_BUTTON_BG_COLOR}, #6644ff)) 85%, white);
-				}
+				.${OverlayManager.RECT_HIGHLIGHT_ACTIVE_CLASS_NAME} .${OverlayManager.RECT_INNER_CLASS_NAME},
+				.${OverlayManager.RECT_HIGHLIGHT_CLASS_NAME}:hover .${OverlayManager.RECT_BUTTON_CLASS_NAME},
+				.${OverlayManager.RECT_BUTTON_CLASS_NAME}:hover,
 				.${OverlayManager.RECT_BUTTON_CLASS_NAME}:hover ~ .${OverlayManager.RECT_INNER_CLASS_NAME},
-				.${OverlayManager.RECT_HIGHLIGHT_CLASS_NAME}:hover .${OverlayManager.RECT_INNER_CLASS_NAME} {
+				.${OverlayManager.RECT_HIGHLIGHT_CLASS_NAME}:hover .${OverlayManager.RECT_INNER_CLASS_NAME},
+				.${OverlayManager.RECT_CLASS_NAME}:has(.${OverlayManager.RECT_BUTTON_CLASS_NAME}:hover) .${OverlayManager.RECT_BUTTON_CLASS_NAME}  {
 					opacity: 1;
 				}
-				.${OverlayManager.RECT_CLASS_NAME}:has(.${OverlayManager.RECT_BUTTON_CLASS_NAME}:hover) .${OverlayManager.RECT_BUTTON_CLASS_NAME} {
-					opacity: 1;
+				.${OverlayManager.RECT_BUTTON_CLASS_NAME}.${OverlayManager.RECT_EDIT_BUTTON_CLASS_NAME}:hover {
+					background-color: color-mix(in srgb, ${editButtonBgColor}, ${buttonBgColorMix});
 				}
-				.${OverlayManager.RECT_CLASS_NAME}:has(.${OverlayManager.RECT_EDIT_BUTTON_CLASS_NAME}:hover) .${OverlayManager.RECT_AI_BUTTON_CLASS_NAME} {
-					background-color: color-mix(in srgb, var(${OverlayManager.CSS_VAR_AI_BUTTON_BG_COLOR}, var(${OverlayManager.CSS_VAR_EDIT_BUTTON_BG_COLOR}, #6644ff)) 85%, white);
-				}
-				.${OverlayManager.RECT_CLASS_NAME}:has(.${OverlayManager.RECT_AI_BUTTON_CLASS_NAME}:hover) .${OverlayManager.RECT_EDIT_BUTTON_CLASS_NAME} {
-					background-color: color-mix(in srgb, var(${OverlayManager.CSS_VAR_EDIT_BUTTON_BG_COLOR}, #6644ff) 85%, white);
-				}
-				.${OverlayManager.RECT_HIGHLIGHT_ACTIVE_CLASS_NAME} .${OverlayManager.RECT_INNER_CLASS_NAME} {
-					opacity: 1;
+				.${OverlayManager.RECT_BUTTON_CLASS_NAME}.${OverlayManager.RECT_AI_BUTTON_CLASS_NAME}:hover {
+					background-color: color-mix(in srgb, ${aiButtonBgColor}, ${buttonBgColorMix});
 				}
 			`),
 		);

--- a/src/lib/overlay-manager.ts
+++ b/src/lib/overlay-manager.ts
@@ -6,6 +6,7 @@ export class OverlayManager {
 	private static readonly CSS_VAR_BORDER_RADIUS = '--directus-visual-editing--rect--border-radius';
 	private static readonly CSS_VAR_HOVER_OPACITY = '--directus-visual-editing--rect-hover--opacity';
 	private static readonly CSS_VAR_HIGHLIGHT_OPACITY = '--directus-visual-editing--rect-highlight--opacity';
+	private static readonly CSS_VAR_ACTIONS_GAP = '--directus-visual-editing--actions--gap';
 	private static readonly CSS_VAR_BUTTON_WIDTH = '--directus-visual-editing--edit-btn--width';
 	private static readonly CSS_VAR_BUTTON_HEIGHT = '--directus-visual-editing--edit-btn--height';
 	private static readonly CSS_VAR_BUTTON_RADIUS = '--directus-visual-editing--edit-btn--radius';
@@ -52,8 +53,10 @@ export class OverlayManager {
 		const style = document.createElement('style');
 		style.id = OverlayManager.STYLE_ID;
 
-		const buttonWidth = 28;
-		const borderSpacing = `var(${OverlayManager.CSS_VAR_BORDER_SPACING}, ${Math.round(buttonWidth * 0.333)}px)`;
+		const buttonSize = 28;
+		const buttonWidth = `var(${OverlayManager.CSS_VAR_BUTTON_WIDTH}, ${buttonSize}px)`;
+		const buttonGap = 4;
+		const borderSpacing = `var(${OverlayManager.CSS_VAR_BORDER_SPACING}, ${Math.round(buttonSize * 0.333)}px)`;
 		const borderWidth = `var(${OverlayManager.CSS_VAR_BORDER_WIDTH}, 2px)`;
 
 		style.appendChild(
@@ -110,8 +113,8 @@ export class OverlayManager {
 					z-index: 1;
 					top: calc(-1 * ${borderSpacing} + ${borderWidth} / 2);
 					transform: translate(-50%, -50%);
-					width: var(${OverlayManager.CSS_VAR_BUTTON_WIDTH}, ${buttonWidth}px);
-					height: var(${OverlayManager.CSS_VAR_BUTTON_HEIGHT}, ${buttonWidth}px);
+					width: ${buttonWidth};
+					height: var(${OverlayManager.CSS_VAR_BUTTON_HEIGHT}, ${buttonSize}px);
 					border-radius: var(${OverlayManager.CSS_VAR_BUTTON_RADIUS}, 50%);
 					background-position: center;
 					background-repeat: no-repeat;
@@ -127,7 +130,7 @@ export class OverlayManager {
 					background-size: var(${OverlayManager.CSS_VAR_EDIT_BUTTON_ICON_BG_SIZE}, 66.6%);
 				}
 				.${OverlayManager.RECT_BUTTON_CLASS_NAME}.${OverlayManager.RECT_AI_BUTTON_CLASS_NAME} {
-					left: calc(-1 * ${borderSpacing} + ${borderWidth} / 2 + var(${OverlayManager.CSS_VAR_BUTTON_WIDTH}, ${buttonWidth}px) + 8px);
+					left: calc(-1 * ${borderSpacing} + ${borderWidth} / 2 + ${buttonWidth} + var(${OverlayManager.CSS_VAR_ACTIONS_GAP}, ${buttonGap}px));
 					background-color: var(${OverlayManager.CSS_VAR_AI_BUTTON_BG_COLOR}, var(${OverlayManager.CSS_VAR_EDIT_BUTTON_BG_COLOR}, #6644ff));
 					background-image: var(${OverlayManager.CSS_VAR_AI_BUTTON_ICON_BG_IMAGE}, ${OverlayManager.ICON_AI});
 					background-size: var(${OverlayManager.CSS_VAR_AI_BUTTON_ICON_BG_SIZE}, 66.6%);


### PR DESCRIPTION
What's changed:

- [fix: update button const names for consistency](https://github.com/directus/visual-editing/commit/0be6e18e9113b2614c540284bf22e59a68613f57)
- [rename aiContext to highlightActive for better reusability](https://github.com/directus/visual-editing/commit/16287b377f25e9d4a6dc542e78f5b9c14bbe9e67)
    - removed the extra css var
    - removed the style that displayed the ai button
- [bring back css reset for pseudos so they don’t get overwritten](https://github.com/directus/visual-editing/commit/ab238ff423a15d47ae7cbad815dcf73e34d15ba6)
- [use separate background size CSS variable for ai button for consistency](https://github.com/directus/visual-editing/commit/55514c567ab4d8ffd2f985904ca4be05e7b1e554)
- [reuse buttonWidth css var, introduce buttonGap var and set it to 4px …](https://github.com/directus/visual-editing/commit/0f72c97dd50dc2d78b6b4ed059e9611458a049cb) (instead of 8px)
- [update button background color variables for consistency](https://github.com/directus/visual-editing/commit/6442fd8076fd7537d7fe1e90ad8a2f7c5b821d47)
    - extracted edit and ai button color vars as const for reusability
    - used the color mix var definition from directus for hover color
    - refactored all selectors that use opacity: 1


Can be reviewed by commit.