### PR TITLE
Add field access checks before activating editable elements

### DIFF
--- a/src/lib/directus-frame.test.ts
+++ b/src/lib/directus-frame.test.ts
@@ -9,6 +9,7 @@ vi.mock('./editable-store.ts', () => ({
 		getItemByEditConfig: vi.fn(),
 		getHoveredItems: vi.fn(),
 		addItem: vi.fn(),
+		activateItems: vi.fn(),
 		enableItems: vi.fn(),
 		disableItems: vi.fn(),
 		removeItems: vi.fn(),
@@ -283,6 +284,41 @@ describe('DirectusFrame', () => {
 					fields: ['title', 'body'],
 				});
 			});
+		});
+	});
+
+	describe('checkFieldAccess action', () => {
+		it('sends checkFieldAccess action with the provided items', () => {
+			const frame = new DirectusFrame();
+			frame.connect(ORIGIN);
+			postMessageSpy.mockClear();
+
+			const items = [{ key: 'k1', collection: 'articles', item: 1, fields: ['title'] }];
+			frame.send('checkFieldAccess', items);
+
+			expect(postMessageSpy).toHaveBeenCalledWith({ action: 'checkFieldAccess', data: items }, ORIGIN);
+		});
+
+		it('activates items with permitted keys when activateElements is received', () => {
+			const frame = new DirectusFrame();
+			frame.connect(ORIGIN);
+
+			frame.send('checkFieldAccess', [{ key: 'k1', collection: 'articles', item: 1, fields: [] }]);
+			frame.receive(makeEvent(ORIGIN, 'activateElements', ['k1']));
+
+			expect(EditableStore.activateItems).toHaveBeenCalledOnce();
+			expect(EditableStore.activateItems).toHaveBeenCalledWith(['k1']);
+		});
+
+		it('activates items with empty array when activateElements data is not an array', () => {
+			const frame = new DirectusFrame();
+			frame.connect(ORIGIN);
+
+			frame.send('checkFieldAccess', []);
+			frame.receive(makeEvent(ORIGIN, 'activateElements', null));
+
+			expect(EditableStore.activateItems).toHaveBeenCalledOnce();
+			expect(EditableStore.activateItems).toHaveBeenCalledWith([]);
 		});
 	});
 

--- a/src/lib/editable-element.test.ts
+++ b/src/lib/editable-element.test.ts
@@ -48,8 +48,9 @@ describe('EditableElement', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('calls rectObserver.observe() in constructor', () => {
-		new EditableElement(createEditableElement());
+	it('calls rectObserver.observe() when activate() is called', () => {
+		const editable = new EditableElement(createEditableElement());
+		editable.activate();
 		expect(mockObserve).toHaveBeenCalledOnce();
 	});
 
@@ -64,8 +65,9 @@ describe('EditableElement', () => {
 	it('sends "edit" action with key, editConfig and rect when edit button is clicked', () => {
 		const el = createEditableElement({ collection: 'articles', item: '42', fields: ['title'] });
 		const editable = new EditableElement(el);
+		editable.activate();
 
-		editable.overlayElement.editButton.click();
+		editable.overlayElement!.editButton.click();
 
 		expect(mockSend).toHaveBeenCalledOnce();
 
@@ -80,8 +82,9 @@ describe('EditableElement', () => {
 		mockIsAiEnabled.mockReturnValue(true);
 		const el = createEditableElement({ collection: 'articles', item: '42', fields: ['title'] });
 		const editable = new EditableElement(el);
+		editable.activate();
 
-		editable.overlayElement.aiButton!.click();
+		editable.overlayElement!.aiButton!.click();
 
 		expect(mockSend).toHaveBeenCalledOnce();
 
@@ -95,6 +98,7 @@ describe('EditableElement', () => {
 	it('sets hover to true on mouseenter and false on mouseleave', () => {
 		const el = createEditableElement();
 		const editable = new EditableElement(el);
+		editable.activate();
 		EditableStore.addItem(editable);
 
 		el.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
@@ -116,8 +120,13 @@ describe('EditableElement', () => {
 			parent.appendChild(child);
 			document.body.appendChild(parent);
 
-			EditableStore.addItem(new EditableElement(parent));
-			EditableStore.addItem(new EditableElement(child));
+			const parentItem = new EditableElement(parent);
+			parentItem.activate();
+			EditableStore.addItem(parentItem);
+
+			const childItem = new EditableElement(child);
+			childItem.activate();
+			EditableStore.addItem(childItem);
 		});
 
 		it('marks parent overlay with parent-hover class when child is hovered', () => {
@@ -140,6 +149,7 @@ describe('EditableElement', () => {
 		it('prevents mouseenter from firing after removeHoverListener is called', () => {
 			const el = createEditableElement();
 			const editable = new EditableElement(el);
+			editable.activate();
 			EditableStore.addItem(editable);
 
 			editable.removeHoverListener();
@@ -151,6 +161,7 @@ describe('EditableElement', () => {
 		it('prevents mouseleave from firing after removeHoverListener is called', () => {
 			const el = createEditableElement();
 			const editable = new EditableElement(el);
+			editable.activate();
 			EditableStore.addItem(editable);
 
 			el.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
@@ -181,6 +192,15 @@ describe('EditableElement', () => {
 			editable.applyOptions({ onSaved: callback2 }, false);
 
 			expect(editable.onSaved).toBe(callback1);
+		});
+
+		it('applies customClass set before activate() once the overlay is created', () => {
+			const editable = new EditableElement(createEditableElement());
+
+			editable.applyOptions({ customClass: 'my-class' });
+			editable.activate();
+
+			expect(document.querySelector('.directus-visual-editing-overlay.my-class')).toBeInstanceOf(HTMLElement);
 		});
 	});
 

--- a/src/lib/editable-store.test.ts
+++ b/src/lib/editable-store.test.ts
@@ -22,7 +22,9 @@ function createEditableElement(config: EditConfig = { collection: 'articles', it
 	const el = document.createElement('div');
 	el.dataset['directus'] = setAttr(config);
 	document.body.appendChild(el);
-	return new EditableElement(el);
+	const item = new EditableElement(el);
+	item.activate();
+	return item;
 }
 
 describe('EditableStore', () => {
@@ -131,6 +133,42 @@ describe('EditableStore', () => {
 		expect(result).not.toContain(item2);
 	});
 
+	describe('activateItems()', () => {
+		it('calls activate() on items whose key is in the list', () => {
+			const item1 = createEditableElement({ collection: 'a', item: '1' });
+			const item2 = createEditableElement({ collection: 'b', item: '2' });
+			EditableStore.addItem(item1);
+			EditableStore.addItem(item2);
+
+			const spy1 = vi.spyOn(item1, 'activate');
+			const spy2 = vi.spyOn(item2, 'activate');
+
+			EditableStore.activateItems([item1.key]);
+
+			expect(spy1).toHaveBeenCalledOnce();
+			expect(spy2).not.toHaveBeenCalled();
+		});
+
+		it('skips items whose key is not in the list', () => {
+			const item = createEditableElement({ collection: 'a', item: '1' });
+			EditableStore.addItem(item);
+
+			const spy = vi.spyOn(item, 'activate');
+
+			EditableStore.activateItems(['non-existent-key']);
+
+			expect(spy).not.toHaveBeenCalled();
+		});
+
+		it('silently skips items not in the store', () => {
+			const item = createEditableElement({ collection: 'a', item: '1' });
+			EditableStore.addItem(item);
+			EditableStore.removeItems([item]);
+
+			expect(() => EditableStore.activateItems([item.key])).not.toThrow();
+		});
+	});
+
 	describe('enableItems()', () => {
 		it('enables all store items when called without arguments', () => {
 			const item1 = createEditableElement({ collection: 'a', item: '1' });
@@ -165,7 +203,7 @@ describe('EditableStore', () => {
 			item.disabled = true;
 			EditableStore.addItem(item);
 
-			const spy = vi.spyOn(item.rectObserver, 'observe');
+			const spy = vi.spyOn(item.rectObserver!, 'observe');
 			spy.mockClear();
 
 			EditableStore.enableItems([item]);
@@ -220,7 +258,7 @@ describe('EditableStore', () => {
 		it('calls rectObserver.unobserve on each disabled item', () => {
 			const item = createEditableElement({ collection: 'a', item: '1' });
 			EditableStore.addItem(item);
-			const spy = vi.spyOn(item.rectObserver, 'unobserve');
+			const spy = vi.spyOn(item.rectObserver!, 'unobserve');
 
 			EditableStore.disableItems([item]);
 
@@ -256,7 +294,7 @@ describe('EditableStore', () => {
 		it('calls rectObserver.unobserve on each removed item', () => {
 			const item = createEditableElement({ collection: 'a', item: '1' });
 			EditableStore.addItem(item);
-			const spy = vi.spyOn(item.rectObserver, 'unobserve');
+			const spy = vi.spyOn(item.rectObserver!, 'unobserve');
 
 			EditableStore.removeItems([item]);
 
@@ -286,7 +324,7 @@ describe('EditableStore', () => {
 		it('calls toggleHighlightActive when highlighting by key', () => {
 			const item = createEditableElement({ collection: 'a', item: '1' });
 			EditableStore.addItem(item);
-			const spy = vi.spyOn(item.overlayElement, 'toggleHighlightActive');
+			const spy = vi.spyOn(item.overlayElement!, 'toggleHighlightActive');
 
 			EditableStore.highlightElement({ key: item.key });
 
@@ -297,7 +335,7 @@ describe('EditableStore', () => {
 		it('calls toggleHighlightActive when highlighting by collection and item', () => {
 			const item = createEditableElement({ collection: 'articles', item: '123' });
 			EditableStore.addItem(item);
-			const spy = vi.spyOn(item.overlayElement, 'toggleHighlightActive');
+			const spy = vi.spyOn(item.overlayElement!, 'toggleHighlightActive');
 
 			EditableStore.highlightElement({ collection: 'articles', item: '123' });
 
@@ -311,8 +349,8 @@ describe('EditableStore', () => {
 			EditableStore.addItem(item1);
 			EditableStore.addItem(item2);
 
-			const spy1 = vi.spyOn(item1.overlayElement, 'toggleHighlightActive');
-			const spy2 = vi.spyOn(item2.overlayElement, 'toggleHighlightActive');
+			const spy1 = vi.spyOn(item1.overlayElement!, 'toggleHighlightActive');
+			const spy2 = vi.spyOn(item2.overlayElement!, 'toggleHighlightActive');
 
 			EditableStore.highlightElement({ key: item1.key });
 			EditableStore.highlightElement({ key: item2.key });
@@ -326,7 +364,7 @@ describe('EditableStore', () => {
 			const item = createEditableElement({ collection: 'a', item: '1' });
 			EditableStore.addItem(item);
 
-			const spy = vi.spyOn(item.overlayElement, 'toggleHighlightActive');
+			const spy = vi.spyOn(item.overlayElement!, 'toggleHighlightActive');
 
 			EditableStore.highlightElement({ key: item.key });
 			EditableStore.highlightElement(null);

--- a/src/lib/editable-store.ts
+++ b/src/lib/editable-store.ts
@@ -35,13 +35,19 @@ export class EditableStore {
 		EditableStore.items.push(item);
 	}
 
+	static activateItems(keys: EditableElement['key'][]) {
+		EditableStore.items.forEach((item) => {
+			if (keys.includes(item.key)) item.activate();
+		});
+	}
+
 	static enableItems(selectedItems?: EditableElement[]) {
 		const items = selectedItems ?? EditableStore.items;
 
 		items.forEach((item) => {
 			item.disabled = false;
-			item.rectObserver.observe();
-			item.overlayElement.enable();
+			item.rectObserver?.observe();
+			item.overlayElement?.enable();
 		});
 	}
 
@@ -51,8 +57,8 @@ export class EditableStore {
 		items.forEach((item) => {
 			item.disabled = true;
 			item.hover = false;
-			item.rectObserver.unobserve();
-			item.overlayElement.disable();
+			item.rectObserver?.unobserve();
+			item.overlayElement?.disable();
 		});
 
 		return [...items];
@@ -62,8 +68,8 @@ export class EditableStore {
 		const items = selectedItems ?? EditableStore.items;
 
 		items.forEach((item) => {
-			item.rectObserver.unobserve();
-			item.overlayElement.remove();
+			item.rectObserver?.unobserve();
+			item.overlayElement?.remove();
 			item.removeHoverListener();
 		});
 
@@ -76,7 +82,7 @@ export class EditableStore {
 		this.highlightOverlayElements = show;
 
 		EditableStore.items.forEach((item) => {
-			item.overlayElement.toggleHighlight(show);
+			item.overlayElement?.toggleHighlight(show);
 		});
 	}
 
@@ -84,7 +90,7 @@ export class EditableStore {
 		identifier: { key: string } | { collection: string; item: string | number; fields?: string[] } | null,
 	) {
 		if (this.highlightedKey !== null) {
-			EditableStore.getItemByKey(this.highlightedKey)?.overlayElement.toggleHighlightActive(false);
+			EditableStore.getItemByKey(this.highlightedKey)?.overlayElement?.toggleHighlightActive(false);
 		}
 
 		if (identifier === null) {
@@ -102,7 +108,7 @@ export class EditableStore {
 
 		if (element) {
 			this.highlightedKey = element.key;
-			element.overlayElement.toggleHighlightActive(true);
+			element.overlayElement?.toggleHighlightActive(true);
 		} else {
 			this.highlightedKey = null;
 		}

--- a/src/lib/types/directus.ts
+++ b/src/lib/types/directus.ts
@@ -18,6 +18,13 @@ export type SavedData = {
 	payload: Record<string, unknown>;
 };
 
+export type CheckFieldAccessData = {
+	key: string;
+	collection: EditConfig['collection'];
+	item: EditConfig['item'];
+	fields: string[];
+};
+
 export type AddToContextData = {
 	key: string;
 	editConfig: EditConfig;
@@ -35,6 +42,6 @@ export type ConfirmData = {
 	aiEnabled: boolean;
 };
 
-export type ReceiveAction = 'connect' | 'edit' | 'navigation' | 'addToContext';
+export type ReceiveAction = 'connect' | 'checkFieldAccess' | 'edit' | 'navigation' | 'addToContext';
 
-export type SendAction = 'confirm' | 'showEditableElements' | 'saved' | 'highlightElement';
+export type SendAction = 'confirm' | 'activateElements' | 'showEditableElements' | 'saved' | 'highlightElement';

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -2,10 +2,10 @@ import type {
 	EditConfig as DirectusEditConfig,
 	ReceiveAction as DirectusReceiveAction,
 	SendAction as DirectusSendAction,
-	SavedData as DirectusSavedData,
-	HighlightElementData as DirectusHighlightElementData,
-	ConfirmData as DirectusConfirmData,
+	SavedData,
 } from './directus.ts';
+
+export type { SavedData, HighlightElementData, ConfirmData, CheckFieldAccessData } from './directus.ts';
 
 export type EditConfigStrict = DirectusEditConfig;
 
@@ -15,10 +15,6 @@ export type SendAction = DirectusReceiveAction;
 export type ReceiveAction = DirectusSendAction;
 
 export type ReceiveData = { action: ReceiveAction | null; data: unknown };
-
-export type SavedData = DirectusSavedData;
-export type HighlightElementData = DirectusHighlightElementData;
-export type ConfirmData = DirectusConfirmData;
 
 export type EditableElementOptions = {
 	customClass?: string | undefined;


### PR DESCRIPTION
## Scope

What's changed:

- Editable elements now go through a two-phase lifecycle: lightweight construction → `activate()` (overlay, observers, listeners) only after permission check
- `apply()` sends a `checkFieldAccess` message to the parent Directus frame with collection/item/fields for each new element
- Parent responds with `activateElements` containing keys of permitted elements — only those get activated
- New types: `CheckFieldAccessData`, new actions: `checkFieldAccess` (send) / `activateElements` (receive)

## Potential Risks / Drawbacks

- **Breaking change**: elements won't show edit overlays unless the parent frame responds to `checkFieldAccess` with `activateElements` — requires **Directus
  v11.16.0+**
- This might warrant bumping to v2.0.0 given the breaking nature

## Review Notes / Questions

- This PR is related to https://github.com/directus/directus/pull/26749
- Should this be released as v2.0.0 due to the breaking change, or is documenting the minimum Directus version in the README sufficient?
- Elements that fail the permission check remain inert (no overlay, no hover listeners, no rect observation) — they stay registered in the store but are never visible
  to the user
